### PR TITLE
Fix Git issue on CI with paths-filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
             buf-vue: vue/**
   ci:
     needs: changes
+    if: ${{ needs.changes.outputs.projects != '' && toJson(fromJson(needs.changes.outputs.projects)) != '[]' }}
     strategy:
       matrix:
         project: ${{ fromJSON(needs.changes.outputs.projects) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     outputs:
       projects: ${{ steps.filter.outputs.changes }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -43,8 +45,6 @@ jobs:
         project: ${{ fromJSON(needs.changes.outputs.projects) }}
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This fixes two issues on CI with `paths-filter`:

1. Perform a checkout prior to the step. For more info, see this issue: https://github.com/dorny/paths-filter/issues/88
2. Only perform CI step if there are prior changes. For more info, see https://github.com/dorny/paths-filter/issues/66