### PR TITLE
Avoid nesting in testing

### DIFF
--- a/react/cra/package.json
+++ b/react/cra/package.json
@@ -6,7 +6,8 @@
     "start": "npm run buf:generate && react-app-rewired start",
     "build": "BUILD_PATH='./dist' react-app-rewired build",
     "test": "jest",
-    "buf:generate": "npx buf generate buf.build/connectrpc/eliza"
+    "buf:generate": "npx buf generate buf.build/connectrpc/eliza",
+    "lint": "npx eslint ."
   },
   "type": "commonjs",
   "eslintConfig": {

--- a/react/cra/src/App.test.tsx
+++ b/react/cra/src/App.test.tsx
@@ -1,81 +1,69 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { createRouterTransport } from "@connectrpc/connect";
 import { ElizaService } from "./gen/connectrpc/eliza/v1/eliza_connect.js";
-import {
-    IntroduceRequest,
-    SayRequest,
-    SayResponse,
-} from "./gen/connectrpc/eliza/v1/eliza_pb.js";
+import { IntroduceRequest, SayRequest, SayResponse } from "./gen/connectrpc/eliza/v1/eliza_pb.js";
 import App from "./App.js";
-import { TransportContext } from "./contexts.js";
+import { TransportContext } from "./use-client.js";
 
-const mockTransport = createRouterTransport(({ service }) => {
-    service(ElizaService, {
-        say(req: SayRequest) {
-            expect(req.sentence).toEqual("Goodbye");
-            return new SayResponse({
-                sentence: "This is a mock response to say.",
-            });
-        },
-        async *introduce(req: IntroduceRequest) {
-            yield {
-                sentence: `Hi ${req.name}, this is a mock response to introduce.`,
-            };
-        },
-    });
-});
-
-describe("mocking transport", () => {
-    let input: HTMLElement;
-    let sendButton: HTMLElement;
-
-    beforeEach(() => {
-        render(
-            <TransportContext.Provider value={mockTransport}>
-                <App />
-            </TransportContext.Provider>,
-        );
-
-        input = screen.getByRole("textbox");
-        sendButton = screen.getByRole("button");
-    });
-
-    test("uses a mock transport", async () => {
-        // The initial prompt from Eliza
-        expect(screen.getByTestId("test0")).toHaveTextContent(
-            "What is your name?",
-        );
-
-        // Enter a name in the input and click send
-        fireEvent.change(input, {
-            target: {
-                value: "Steve",
+test("against a mocked service", async () => {
+    const mockTransport = createRouterTransport(({ service }) => {
+        service(ElizaService, {
+            say(req: SayRequest) {
+                expect(req.sentence).toEqual("Goodbye");
+                return new SayResponse({
+                    sentence: "This is a mock response to say.",
+                });
+            },
+            async *introduce(req: IntroduceRequest) {
+                yield {
+                    sentence: `Hi ${req.name}, this is a mock response to introduce.`,
+                };
             },
         });
-        fireEvent.click(sendButton);
-
-        // The sent name should appear as the next response in the chat
-        expect(screen.getByTestId("test1")).toHaveTextContent("Steve");
-
-        // Wait for the introduce response from our mocked Eliza and verify it is our mocked response
-        let response = await screen.findByTestId("test2");
-        expect(response).toHaveTextContent(
-            "Hi Steve, this is a mock response to introduce.",
-        );
-
-        // Enter another response in the input and click send
-        fireEvent.change(input, {
-            target: {
-                value: "Goodbye",
-            },
-        });
-        fireEvent.click(sendButton);
-
-        // The new response should again appear in the chat
-        expect(screen.getByTestId("test3")).toHaveTextContent("Goodbye");
-
-        // Wait for the say response from our mocked Eliza and verify it is our mocked response
-        response = await screen.findByTestId("test4");
-        expect(response).toHaveTextContent("This is a mock response to say");
     });
+    render(
+        <TransportContext.Provider value={mockTransport}>
+            <App />
+        </TransportContext.Provider>,
+    );
+
+    const input = screen.getByRole("textbox");
+    const sendButton = screen.getByRole("button");
+
+    // The initial prompt from Eliza
+    expect(screen.getByTestId("test0")).toHaveTextContent(
+        "What is your name?",
+    );
+
+    // Enter a name in the input and click send
+    fireEvent.change(input, {
+        target: {
+            value: "Steve",
+        },
+    });
+    fireEvent.click(sendButton);
+
+    // The sent name should appear as the next response in the chat
+    expect(screen.getByTestId("test1")).toHaveTextContent("Steve");
+
+    // Wait for the introduce response from our mocked Eliza and verify it is our mocked response
+    let response = await screen.findByTestId("test2");
+    expect(response).toHaveTextContent(
+        "Hi Steve, this is a mock response to introduce.",
+    );
+
+    // Enter another sentence and click send
+    fireEvent.change(input, {
+        target: {
+            value: "Goodbye",
+        },
+    });
+    fireEvent.click(sendButton);
+
+    // The new response should again appear in the chat
+    expect(screen.getByTestId("test3")).toHaveTextContent("Goodbye");
+
+    // Wait for the say response from our mocked Eliza and verify it is our mocked response
+    response = await screen.findByTestId("test4");
+    expect(response).toHaveTextContent("This is a mock response to say");
 });

--- a/react/cra/src/contexts.ts
+++ b/react/cra/src/contexts.ts
@@ -1,4 +1,0 @@
-import { createContext } from "react";
-import { Transport } from "@connectrpc/connect";
-
-export const TransportContext = createContext<Transport | null>(null);

--- a/react/cra/src/index.tsx
+++ b/react/cra/src/index.tsx
@@ -3,22 +3,13 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App.js";
 import reportWebVitals from "./reportWebVitals.js";
-import { createConnectTransport } from "@connectrpc/connect-web";
-import { TransportContext } from "./contexts.js";
-
-// This transport is going to be used throughout the app
-const transport = createConnectTransport({
-    baseUrl: "https://demo.connectrpc.com",
-});
 
 const root = ReactDOM.createRoot(
     document.getElementById("root") as HTMLElement,
 );
 root.render(
     <React.StrictMode>
-        <TransportContext.Provider value={transport}>
-            <App />
-        </TransportContext.Provider>
+        <App />
     </React.StrictMode>,
 );
 

--- a/react/cra/src/use-client.ts
+++ b/react/cra/src/use-client.ts
@@ -1,18 +1,21 @@
-import { useContext, useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 import { ServiceType } from "@bufbuild/protobuf";
-import { createPromiseClient, PromiseClient } from "@connectrpc/connect";
-import { TransportContext } from "./contexts.js";
+import { createPromiseClient, PromiseClient, Transport } from "@connectrpc/connect";
+import { createConnectTransport } from "@connectrpc/connect-web";
+
+// This transport is going to be used throughout the app
+const defaultTransport = createConnectTransport({
+    baseUrl: "https://demo.connectrpc.com",
+});
+
+// A context to override the default transport in tests
+export const TransportContext = createContext<Transport>(defaultTransport);
 
 /**
  * Get a promise client for the given service.
  */
 export function useClient<T extends ServiceType>(service: T): PromiseClient<T> {
     const transport = useContext(TransportContext);
-
-    if (!transport) {
-        throw new Error("No transport specified in TransportContext");
-    }
-
     // We memoize the client, so that we only create one instance per service.
     return useMemo(
         () => createPromiseClient(service, transport),

--- a/svelte/src/tests/page.spec.ts
+++ b/svelte/src/tests/page.spec.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import flushPromises from "flush-promises";
-import { beforeEach, describe, it, expect } from "vitest";
+import { test, expect } from "vitest";
 import type { ComponentType } from "svelte";
 import { render, fireEvent, screen } from "@testing-library/svelte";
 import { createRouterTransport } from "@connectrpc/connect";
@@ -28,67 +28,59 @@ function renderWithMockRoutes(
   });
 }
 
-describe("ElizaView", () => {
-  let input: HTMLElement;
-  let sendButton: HTMLElement;
-
-  beforeEach(() => {
-    renderWithMockRoutes(ElizaPage, ({ service }) => {
+test("against a mocked service", async () => {
+  renderWithMockRoutes(ElizaPage, ({ service }) => {
       service(ElizaService, {
-        say(req: SayRequest) {
-          expect(req.sentence).toEqual("Goodbye");
-          return new SayResponse({
-            sentence: "This is a mock response to say.",
-          });
-        },
-        async *introduce(req: IntroduceRequest) {
-          yield {
-            sentence: `Hi ${req.name}, this is a mock response to introduce.`,
-          };
-        },
+          say(req: SayRequest) {
+              expect(req.sentence).toEqual("Goodbye");
+              return new SayResponse({
+                  sentence: "This is a mock response to say.",
+              });
+          },
+          async *introduce(req: IntroduceRequest) {
+              yield {
+                  sentence: `Hi ${req.name}, this is a mock response to introduce.`,
+              };
+          },
       });
-    });
-
-    input = screen.getByRole("textbox");
-    sendButton = screen.getByRole("button");
   });
+  const input = screen.getByRole("textbox");
+  const sendButton = screen.getByRole("button");
 
-  it("uses a mock transport", async () => {
-    // The initial prompt from Eliza
-    expect(screen.getByTestId("test0")).toHaveTextContent("What is your name?");
+  // The initial prompt from Eliza
+  expect(screen.getByTestId("test0")).toHaveTextContent("What is your name?");
 
-    // Enter a name in the input and click send
-    fireEvent.input(input, {
-      target: {
-        value: "Steve",
-      },
-    });
-    await fireEvent.click(sendButton);
-    await flushPromises();
-
-    // The sent name should appear as the next response in the chat
-    expect(screen.getByTestId("test1")).toHaveTextContent("Steve");
-
-    // // Wait for the introduce response from our mocked Eliza and verify it is our mocked response
-    let response = await screen.findByTestId("test2");
-    expect(response).toHaveTextContent(
-      "Hi Steve, this is a mock response to introduce.",
-    );
-
-    // Enter another response in the input and click send
-    fireEvent.input(input, {
-      target: {
-        value: "Goodbye",
-      },
-    });
-    await fireEvent.click(sendButton);
-    await flushPromises();
-
-    // The new response should again appear in the chat
-    expect(screen.getByTestId("test3")).toHaveTextContent("Goodbye");
-
-    // Wait for the say response from our mocked Eliza and verify it is our mocked response
-    response = await screen.findByTestId("test4");
-    expect(response).toHaveTextContent("This is a mock response to say");
+  // Enter a name in the input and click send
+  fireEvent.input(input, {
+    target: {
+      value: "Steve",
+    },
   });
+  await fireEvent.click(sendButton);
+  await flushPromises();
+
+  // The sent name should appear as the next response in the chat
+  expect(screen.getByTestId("test1")).toHaveTextContent("Steve");
+
+  // // Wait for the introduce response from our mocked Eliza and verify it is our mocked response
+  let response = await screen.findByTestId("test2");
+  expect(response).toHaveTextContent(
+    "Hi Steve, this is a mock response to introduce.",
+  );
+
+  // Enter another response in the input and click send
+  fireEvent.input(input, {
+    target: {
+      value: "Goodbye",
+    },
+  });
+  await fireEvent.click(sendButton);
+  await flushPromises();
+
+  // The new response should again appear in the chat
+  expect(screen.getByTestId("test3")).toHaveTextContent("Goodbye");
+
+  // Wait for the say response from our mocked Eliza and verify it is our mocked response
+  response = await screen.findByTestId("test4");
+  expect(response).toHaveTextContent("This is a mock response to say");
 });

--- a/vue/src/views/__tests__/ElizaView.spec.ts
+++ b/vue/src/views/__tests__/ElizaView.spec.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, it, expect } from "vitest";
-import { flushPromises, mount, DOMWrapper, VueWrapper } from "@vue/test-utils";
+import { test, expect } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
 import { createRouterTransport } from "@connectrpc/connect";
 import { ElizaService } from "../../gen/connectrpc/eliza/v1/eliza_connect";
 import {
@@ -10,63 +10,54 @@ import {
 import ElizaView from "../ElizaView.vue";
 import { transportKey } from "../../keys";
 
-const mockTransport = createRouterTransport(({ service }) => {
-    service(ElizaService, {
-        say(req: SayRequest) {
-            expect(req.sentence).toEqual("Goodbye");
-            return new SayResponse({
-                sentence: "This is a mock response to say.",
-            });
-        },
-        async *introduce(req: IntroduceRequest) {
-            yield {
-                sentence: `Hi ${req.name}, this is a mock response to introduce.`,
-            };
-        },
-    });
-});
 
-describe("ElizaView", () => {
-    let input: DOMWrapper<Element>;
-    let sendButton: DOMWrapper<Element>;
-    let wrapper: VueWrapper;
-
-    beforeEach(() => {
-        wrapper = mount(ElizaView, {
-            global: {
-                provide: {
-                    [transportKey]: mockTransport,
-                },
+test("against a mocked service", async () => {
+    const mockTransport = createRouterTransport(({ service }) => {
+        service(ElizaService, {
+            say(req: SayRequest) {
+                expect(req.sentence).toEqual("Goodbye");
+                return new SayResponse({
+                    sentence: "This is a mock response to say.",
+                });
+            },
+            async *introduce(req: IntroduceRequest) {
+                yield {
+                    sentence: `Hi ${req.name}, this is a mock response to introduce.`,
+                };
             },
         });
-
-        input = wrapper.find("#statement-input");
-        sendButton = wrapper.find("#send-button");
     });
-
-    it("uses a mock transport", async () => {
-        let fi = wrapper.findAll(".eliza-resp-container p");
-
-        expect(fi.at(0)?.text()).toContain("What is your name?");
-
-        // Enter a name in the input and click send
-        await input.setValue("Steve");
-        await sendButton.trigger("click");
-
-        // Wait for the introduce response from our mocked Eliza and verify it is our mocked response
-        await flushPromises();
-        fi = wrapper.findAll(".eliza-resp-container p");
-        expect(fi.at(1)?.text()).toContain(
-            "Hi Steve, this is a mock response to introduce.",
-        );
-
-        // Enter another response in the input and click send
-        await input.setValue("Goodbye");
-        await sendButton.trigger("click");
-
-        // Wait for the say response from our mocked Eliza and verify it is our mocked response
-        await flushPromises();
-        fi = wrapper.findAll(".eliza-resp-container p");
-        expect(fi.at(2)?.text()).toContain("This is a mock response to say");
+    const wrapper = mount(ElizaView, {
+        global: {
+            provide: {
+                [transportKey]: mockTransport,
+            },
+        },
     });
+    const input = wrapper.find("#statement-input");
+    const sendButton = wrapper.find("#send-button");
+
+    let fi = wrapper.findAll(".eliza-resp-container p");
+
+    expect(fi.at(0)?.text()).toContain("What is your name?");
+
+    // Enter a name in the input and click send
+    await input.setValue("Steve");
+    await sendButton.trigger("click");
+
+    // Wait for the introduce response from our mocked Eliza and verify it is our mocked response
+    await flushPromises();
+    fi = wrapper.findAll(".eliza-resp-container p");
+    expect(fi.at(1)?.text()).toContain(
+        "Hi Steve, this is a mock response to introduce.",
+    );
+
+    // Enter another response in the input and click send
+    await input.setValue("Goodbye");
+    await sendButton.trigger("click");
+
+    // Wait for the say response from our mocked Eliza and verify it is our mocked response
+    await flushPromises();
+    fi = wrapper.findAll(".eliza-resp-container p");
+    expect(fi.at(2)?.text()).toContain("This is a mock response to say");
 });


### PR DESCRIPTION
The test in the react/cra example had a lint issue for the `testing-library/no-render-in-setup` rule that went unnoticed because of https://github.com/connectrpc/examples-es/issues/915.

The gist of the rule is best described by this article from the creator of the react testing library: https://kentcdodds.com/blog/avoid-nesting-when-youre-testing.

This PR fixes the lint issue and makes the same change for the vue and svelte examples.