### PR TITLE
Allow skipping packages during processes

### DIFF
--- a/manage.mjs
+++ b/manage.mjs
@@ -38,10 +38,13 @@ function main() {
         onlyPackages.push(pkg);
       }
     });
+    if (onlyPackages.length > 0 && notPackages.length > 0) {
+      process.stderr.write("either a list of packages or a list of skipped packages must be provided, but not both");
+      process.exit(1);
+    }
     if (onlyPackages.length > 0) {
         packages = packages.filter(p => onlyPackages.includes(p.name));
-    }
-    if (notPackages.length > 0) {
+    } else if (notPackages.length > 0) {
         packages = packages.filter(p => !notPackages.includes(p.name));
     }
     switch (command) {

--- a/manage.mjs
+++ b/manage.mjs
@@ -28,10 +28,21 @@ const knownDependencies = [
 
 function main() {
     const command = process.argv[2];
-    const onlyPackages = process.argv.splice(3);
+    const packageList = process.argv.splice(3);
     let packages = listPackages(process.cwd());
+    let onlyPackages = [], notPackages = [];
+    packageList.forEach((pkg) => {
+      if (pkg.startsWith("!")) {
+        notPackages.push(pkg.substring(1));
+      } else {
+        onlyPackages.push(pkg);
+      }
+    });
     if (onlyPackages.length > 0) {
         packages = packages.filter(p => onlyPackages.includes(p.name));
+    }
+    if (notPackages.length > 0) {
+        packages = packages.filter(p => !notPackages.includes(p.name));
     }
     switch (command) {
         case "list":

--- a/manage.mjs
+++ b/manage.mjs
@@ -32,17 +32,17 @@ function main() {
     let packages = listPackages(process.cwd());
     let onlyPackages = [], notPackages = [];
     packageList.forEach((pkg) => {
-      if (pkg.startsWith("!")) {
-        notPackages.push(pkg.substring(1));
-      } else {
-        onlyPackages.push(pkg);
-      }
+        if (pkg.startsWith("!")) {
+            notPackages.push(pkg.substring(1));
+        } else {
+            onlyPackages.push(pkg);
+        }
     });
-    if (onlyPackages.length > 0 && notPackages.length > 0) {
-      process.stderr.write("either a list of packages or a list of skipped packages must be provided, but not both");
-      process.exit(1);
-    }
     if (onlyPackages.length > 0) {
+        if (notPackages.length > 0) {
+            process.stderr.write("either a list of packages or a list of skipped packages must be provided, but not both");
+            process.exit(1);
+        }
         packages = packages.filter(p => onlyPackages.includes(p.name));
     } else if (notPackages.length > 0) {
         packages = packages.filter(p => !notPackages.includes(p.name));
@@ -89,6 +89,7 @@ function main() {
             console.error("'update' updates all deps to the latest version allowed by the dependency constraints.");
             console.error("'forceupdateknown' updates all known deps to the latest version, regardless of constraints.");
             console.error("'forceupdateall' updates all deps to the latest version, regardless of constraints.");
+            console.error("To skip a package, wrap it in single quotes and prefix it with `!`. i.e. '!buf-ng'");
             console.error("If no packages are given, the command runs for all packages.");
             process.exit(1);
     }


### PR DESCRIPTION
There are occasions when updating dependencies for a certain project fail, which in turn, fails the entire process. For example, today (5/1), updating the `react-native` project failed as a result of peer dependencies. To get the rest of the projects to update, `react-native` had to be manually skipped.

This allows for skipping packages when running a process by prefixing it with `!`. For example:

`./manage.mjs list '!buf-react-native'`