### PR TITLE
Fix polyfills using expo-dev-client and platform splitting

### DIFF
--- a/react-native/.gitignore
+++ b/react-native/.gitignore
@@ -9,6 +9,8 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
+android
+ios
 
 # macOS
 .DS_Store

--- a/react-native/app.json
+++ b/react-native/app.json
@@ -13,21 +13,19 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
+      "bundleIdentifier": "com.eliza.app",
       "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.eliza.app"
     },
     "web": {
-      "bundler": "metro",
-      "output": "static",
-      "favicon": "./assets/images/favicon.png"
+      "bundler": "metro"
     },
-    "plugins": [
-      "expo-router"
-    ]
+    "plugins": ["expo-router"]
   }
 }

--- a/react-native/app/polyfills.native.ts
+++ b/react-native/app/polyfills.native.ts
@@ -1,0 +1,20 @@
+import TextEncoder from "react-native-fast-encoder";
+// @ts-expect-error -- missing type declarations
+import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions";
+// @ts-expect-error -- missing type declarations
+import { fetch, Headers, Request, Response } from "react-native-fetch-api";
+import { ReadableStream } from "web-streams-polyfill";
+
+export function polyfills() {
+  polyfillGlobal("ReadableStream", () => ReadableStream);
+  polyfillGlobal("TextDecoder", () => TextEncoder);
+  polyfillGlobal("TextEncoder", () => TextEncoder);
+  polyfillGlobal("fetch", () => fetch);
+  polyfillGlobal("Headers", () => Headers);
+  polyfillGlobal("Request", () => Request);
+  polyfillGlobal("Response", () => Response);
+  // Polyfill async.Iterator. For some reason, the Babel presets and plugins are not doing the trick.
+  // Code from here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#caveats
+  (Symbol as any).asyncIterator =
+    Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator");
+}

--- a/react-native/app/polyfills.ts
+++ b/react-native/app/polyfills.ts
@@ -1,20 +1,2 @@
-import TextEncoder from "react-native-fast-encoder"
-import { ReadableStream } from "web-streams-polyfill"
-// @ts-expect-error -- missing type declarations
-import { polyfillGlobal } from "react-native/Libraries/Utilities/PolyfillFunctions"
-// @ts-expect-error -- missing type declarations
-import { fetch, Headers, Request, Response } from "react-native-fetch-api"
-
-export function polyfills() {
-  polyfillGlobal("ReadableStream", () => ReadableStream);
-  polyfillGlobal("TextDecoder", () => TextEncoder);
-  polyfillGlobal("TextEncoder", () => TextEncoder);
-  polyfillGlobal("fetch", () => fetch);
-  polyfillGlobal("Headers", () => Headers);
-  polyfillGlobal("Request", () => Request);
-  polyfillGlobal("Response", () => Response);
-  // Polyfill async.Iterator. For some reason, the Babel presets and plugins are not doing the trick.
-  // Code from here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#caveats
-  (Symbol as any).asyncIterator =
-    Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator");
-}
+// No polyfills needed for web
+export function polyfills() {}

--- a/react-native/package-lock.json
+++ b/react-native/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/native": "^6.1.17",
         "expo": "^51.0.17",
         "expo-constants": "^16.0.2",
+        "expo-dev-client": "^4.0.19",
         "expo-font": "^12.0.7",
         "expo-linking": "^6.3.1",
         "expo-router": "^3.5.17",
@@ -10809,6 +10810,100 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-4.0.19.tgz",
+      "integrity": "sha512-u3CwIWpLqwVex4vvK9+2qtf17CYxaLXA7PJgtRB2dTsqIXJwyoazZZEMK6wjoL58Tp6GC7v9O9Z6lpayZ4BDKA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "4.0.21",
+        "expo-dev-menu": "5.0.15",
+        "expo-dev-menu-interface": "1.8.3",
+        "expo-manifests": "~0.14.0",
+        "expo-updates-interface": "~0.16.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-4.0.21.tgz",
+      "integrity": "sha512-o2KHD0d0yNbF4NKdtGmxc6l4l/xfpTHaFSSvKXTC2ardh7moeLX02ich5qSsqSqCCQkZ2BBelYAfZUOH9cGuqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.11.0",
+        "expo-dev-menu": "5.0.15",
+        "expo-manifests": "~0.14.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-5.0.15.tgz",
+      "integrity": "sha512-a5aADQXOH/uw2NDy4fbgVl9wkAcZIfkrz8yzwQz0X6Yvf0a68zafqxSvvYkq+MmUTrFsuiST49s+mk4uRqHJMw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "1.8.3",
+        "semver": "^7.5.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.8.3.tgz",
+      "integrity": "sha512-QM0LRozeFT5Ek0N7XpV93M+HMdEKRLEOXn0aW5M3uoUlnqC1+PLtF3HMy3k3hMKTTE/kJ1y1Z7akH07T0lunCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-17.0.1.tgz",
@@ -10828,6 +10923,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.13.1.tgz",
+      "integrity": "sha512-mlfaSArGVb+oJmUcR22jEONlgPp0wj4iNIHfQ2je9Q8WTOqMc0Ws9tUciz3JdJnhffdHqo/k8fpvf0IRmN5HPA==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-13.0.2.tgz",
@@ -10843,6 +10944,19 @@
       "dependencies": {
         "expo-constants": "~16.0.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.14.3.tgz",
+      "integrity": "sha512-L3b5/qocBPiQjbW0cpOHfnqdKZbTJS7sA3mgeDJT+mWga/xYsdpma1EfNmsuvrOzjLGjStr1k1fceM9Bl49aqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~9.0.0",
+        "expo-json-utils": "~0.13.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -11034,6 +11148,15 @@
       "version": "0.74.84",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.84.tgz",
       "integrity": "sha512-Y5W6x8cC5RuakUcTVUFNAIhUZ/tYpuqHZlRBoAuakrTwVuoNHXfQki8lj1KsYU7rW6e3VWgdEx33AfOQpdNp6A=="
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.16.2.tgz",
+      "integrity": "sha512-929XBU70q5ELxkKADj1xL0UIm3HvhYhNAOZv5DSk7rrKvLo7QDdPyl+JVnwZm9LrkNbH4wuE2rLoKu1KMgZ+9A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
     },
     "node_modules/expo-web-browser": {
       "version": "13.0.3",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -9,13 +9,16 @@
     "test": "jest",
     "lint": "expo lint",
     "generate": "buf generate buf.build/connectrpc/eliza",
-    "ci": "npm run generate && npm run build && npm run test"
+    "ci": "npm run generate && npm run build && npm run test",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/native": "^6.1.17",
     "expo": "^51.0.17",
     "expo-constants": "^16.0.2",
+    "expo-dev-client": "^4.0.19",
     "expo-font": "^12.0.7",
     "expo-linking": "^6.3.1",
     "expo-router": "^3.5.17",


### PR DESCRIPTION
Fixes the RN polyfill updates by:

1. Updating the app to use `expo-dev-client`. This was required as `react-native-fast-encoder` is a native JSI implementation and not provided in expo go.
2. Platform splitting the polyfills. The RN polyfill function is unfortunately a deep import and causes us to run into [errors](https://github.com/expo/fyi/blob/main/fb-batched-bridge-config-web.md) on web unless we completely remove that code from the web bundle.

Demo:
<img width="1583" alt="Screenshot 2024-07-09 at 4 16 44 PM" src="https://github.com/connectrpc/examples-es/assets/1944151/44bbcc4a-031d-44d6-a517-8583a2763298">
