### PR TITLE
V2: Add example for crossing the Next.js serialization boundary

### DIFF
--- a/nextjs/app/boundary/client.tsx
+++ b/nextjs/app/boundary/client.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Payload } from "../../gen/payload_pb";
+
+export default function Client(props: { payload: Payload }) {
+  return (
+    <div>
+      <h5>Payload&apos;s large number, rendered on the client</h5>
+      <pre>{props.payload.largeNumber.toString()}</pre>
+    </div>
+  );
+}

--- a/nextjs/app/boundary/page.tsx
+++ b/nextjs/app/boundary/page.tsx
@@ -1,0 +1,32 @@
+import { create } from "@bufbuild/protobuf";
+import { PayloadSchema } from "../../gen/payload_pb";
+import Client from "./client";
+
+
+export default function Page() {
+
+  // We can pass the Protobuf message `Payload` to a client side component as a
+  // prop.
+  //
+  // Next.js can handle bigint, Infinity and typed arrays when crossing the
+  // serialization boundary, since they are serializable by React. For details,
+  // see https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#passing-props-from-server-to-client-components-serialization
+  //
+  // Note that proto2 messages use the prototype chain to track field presence,
+  // which Next.js does not support when crossing the boundary. If you encounter
+  // such a case, you have the following options:
+  // - Serialize to JSON and reparse using the schema.
+  // - Use the plugin option `json_types=true` to get typed JSON from toJson().
+  const payload = create(PayloadSchema, {
+    str: "abc",
+    double: Number.POSITIVE_INFINITY,
+    largeNumber: 123n,
+    bytes: new Uint8Array([0, 1, 2]),
+  });
+
+  return (
+    <div>
+      <Client payload={payload}></Client>
+    </div>
+  );
+}

--- a/nextjs/app/layout.tsx
+++ b/nextjs/app/layout.tsx
@@ -17,17 +17,13 @@ export default function RootLayout({
       <body>
         <header className={styles.appHeader}>
           <h1 className={styles.headline}>Connect with Next.js</h1>
-          <h4 className={styles.subtitle}>
-            React Server Components with Server actions
-          </h4>
           <div className={styles.links}>
             Choose an example:
             <Link href="/">Unary Calls</Link>
             <Link href="/server-streaming">Server Streaming Calls</Link>
             <Link href="/ssr">SSR</Link>
-            <Link href="/react-server-actions">
-              React Server Components with Server actions
-            </Link>
+            <Link href="/react-server-actions">Server actions</Link>
+            <Link href="/boundary">Boundary</Link>
           </div>
         </header>
         <div className={styles.container}>{children}</div>

--- a/nextjs/next.config.js
+++ b/nextjs/next.config.js
@@ -5,20 +5,6 @@ const nextConfig = {
   experimental: {
     serverActions: true,
   },
-  // Allow the .js extension in import paths when importing TypeScript files.
-  // It is the standard for ECMAScript modules, but not all bundlers have
-  // caught up yet.
-  // Alternatively, add the plugin option `import_extension=none` in buf.gen.yaml.
-  //   webpack: (config) => {
-  //     config.resolve = {
-  //       ...config.resolve,
-  //       extensionAlias: {
-  //         ".js": [".ts", ".js"],
-  //       },
-  //     };
-
-  //     return config;
-  //   },
 };
 
 module.exports = nextConfig;

--- a/nextjs/pages/index.tsx
+++ b/nextjs/pages/index.tsx
@@ -51,9 +51,8 @@ const UnaryExample: FC = () => {
           <Link href="/">Unary Calls</Link>
           <Link href="/server-streaming">Server Streaming Calls</Link>
           <Link href="/ssr">SSR</Link>
-          <Link href="/react-server-actions">
-            React Server Components with Server actions
-          </Link>
+          <Link href="/react-server-actions">Server actions</Link>
+          <Link href="/boundary">Boundary</Link>
         </div>
       </header>
       <div className={styles.container}>

--- a/nextjs/pages/server-streaming.tsx
+++ b/nextjs/pages/server-streaming.tsx
@@ -39,9 +39,8 @@ const NewPage: FC = () => {
           <Link href="/">Unary Calls</Link>
           <Link href="/server-streaming">Server Streaming Calls</Link>
           <Link href="/ssr">SSR</Link>
-          <Link href="/react-server-actions">
-            React Server Components with Server actions
-          </Link>
+          <Link href="/react-server-actions">Server actions</Link>
+          <Link href="/boundary">Boundary</Link>
         </div>
       </header>
       <div className={styles.container}>

--- a/nextjs/pages/ssr.tsx
+++ b/nextjs/pages/ssr.tsx
@@ -70,9 +70,8 @@ function Ssr({
           <Link href="/">Unary Calls</Link>
           <Link href="/server-streaming">Server Streaming Calls</Link>
           <Link href="/ssr">SSR</Link>
-          <Link href="/react-server-actions">
-            React Server Components with Server actions
-          </Link>
+          <Link href="/react-server-actions">Server actions</Link>
+          <Link href="/boundary">Boundary</Link>
         </div>
       </header>
 


### PR DESCRIPTION
When props are passed from a server component to a client component, the data crosses the [serialization boundary](https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#passing-props-from-server-to-client-components-serialization).

This required the `toPlainmessage()` function and the `PlainMessage` type with Protobuf-ES v1. With v2, it works out of the box for messages that do not track field presence - all proto3 messages, and edition 2023 messages with the equivalent feature settings.

This PR adds an example.