### PR TITLE
Add Sri Krishna as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,3 +5,4 @@ Maintainers
 * [Timo Stamm](https://github.com/timostamm), [Buf](https://buf.build)
 * [Steve Ayers](https://github.com/smaye81), [Buf](https://buf.build)
 * [Paul Sachs](https://github.com/paul-sachs), [Buf](https://buf.build)
+* [Sri Krishna](https://github.com/srikrsna-buf), [Buf](https://buf.build)


### PR DESCRIPTION
This proposes adding @srikrsna-buf (from Buf) to the list of maintainers, following [Connect's governance policy](https://connectrpc.com/docs/governance/project-governance).
