### PR TITLE
Fix nextjs Server Actions example

### DIFF
--- a/nextjs/app/react-server-actions/page.tsx
+++ b/nextjs/app/react-server-actions/page.tsx
@@ -5,7 +5,9 @@ import { ElizaService } from "../../gen/connectrpc/eliza/v1/eliza_pb";
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { getMessages, addMessage } from "./fake-db";
 
-const getMessagesCached = unstable_cache(getMessages, ["my-messages"]);
+const getMessagesCached = unstable_cache(getMessages, ["my-messages"], {
+  tags: ["my-messages"],
+});
 
 export default async function Page() {
   // This action runs on the server


### PR DESCRIPTION
This fixes the nextjs "Server actions" example. This was caused by `unstable_cache(fn, keyParts, options)` which takes [three arguments](https://nextjs.org/docs/app/api-reference/functions/unstable_cache#parameters). The second (`keyParts`) is for cache key generation, while tags must be specified in the third argument (options). Without tags, `revalidateTag("my-messages")` in the server action was a no-op, so the cached getMessages result never invalidated and the UI always re-rendered with stale data. 

<img width="1544" height="587" alt="Screenshot 2026-04-13 at 7 49 58 PM" src="https://github.com/user-attachments/assets/91939ebe-1bcf-4f11-8228-ffaf2b43c00a" />
